### PR TITLE
Remove wait -p

### DIFF
--- a/dtensor-app-naive.py
+++ b/dtensor-app-naive.py
@@ -26,7 +26,7 @@ Sample usage:
 1. Run on a single host with 8 GPUs:
 
 ```
-python dtensor_app_naive.py --device_type=GPU --num_global_devices=8
+python dtensor-app-naive.py --device_type=GPU --num_global_devices=8
 ```
 
 2. Run on 2 hosts with 16 GPUs:
@@ -36,14 +36,14 @@ python dtensor_app_naive.py --device_type=GPU --num_global_devices=8
 env DTENSOR_CLIENT_ID=0 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --device_type=GPU --num_global_devices=16
+python dtensor-app-naive.py --device_type=GPU --num_global_devices=16
 ```
 
 ```For host2
 env DTENSOR_CLIENT_ID=1 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --device_type=GPU --num_global_devices=16
+python dtensor-app-naive.py --device_type=GPU --num_global_devices=16
 ```
 
 """

--- a/dtensor-app-naive.py
+++ b/dtensor-app-naive.py
@@ -26,8 +26,7 @@ Sample usage:
 1. Run on a single host with 8 GPUs:
 
 ```
-python dtensor_app_naive.py --device_type=GPU \
-  --num_accelerator=8
+python dtensor_app_naive.py --device_type=GPU --num_global_devices=8
 ```
 
 2. Run on 2 hosts with 16 GPUs:
@@ -37,16 +36,14 @@ python dtensor_app_naive.py --device_type=GPU \
 env DTENSOR_CLIENT_ID=0 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
-  --num_global_devices=16
+python dtensor_bert_train.py --device_type=GPU --num_global_devices=16
 ```
 
 ```For host2
 env DTENSOR_CLIENT_ID=1 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
-  --num_global_devices=16
+python dtensor_bert_train.py --device_type=GPU --num_global_devices=16
 ```
 
 """

--- a/dtensor-app-naive.py
+++ b/dtensor-app-naive.py
@@ -98,7 +98,7 @@ def configure_virtual_devices(num_device, device_type):
       tf.config.set_logical_device_configuration(phy_devices[n],
                                                  [device_config])
   else:
-    phy_to_logical_ratio = math.ceil(num_device / len(phy_devices))
+    phy_to_logical_ratio = num_device // len(phy_devices)
     for n in range(len(phy_devices)):
       print(f'Config for device id {n}')
       tf.config.set_logical_device_configuration(phy_devices[n], [
@@ -148,7 +148,7 @@ def main():
   # Checkpointing
   v = dtensor.DVariable(data)
   cpt = dtensor.DTensorCheckpoint(mesh=mesh, v=v)
-  saved_path = cpt.save(os.path.join(args.prefix, 'checkpoint-1'))
+  saved_path = cpt.save(os.path.join(args.ckpt_path_prefix, 'checkpoint-1'))
   # Restoring checkpoint
   cpt.restore(saved_path)
 

--- a/dtensor-keras-bert.py
+++ b/dtensor-keras-bert.py
@@ -29,7 +29,7 @@ Sample usage:
 This will run the Bert model with a 4x2 mesh (data x model).
 
 ```
-python dtensor_bert_train.py --model_size=tiny --device_type=GPU \
+python dtensor-bert-train.py --model_size=tiny --device_type=GPU \
   --num_accelerator=8 --distribution_mode=batchmodel
 ```
 
@@ -37,7 +37,7 @@ python dtensor_bert_train.py --model_size=tiny --device_type=GPU \
 This will run the Bert model with data parallel only.
 
 ```
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
+python dtensor-bert-train.py --model_size=base --device_type=GPU \
   --num_global_devices=8 --distribution_mode=batch
 ```
 
@@ -46,7 +46,7 @@ This will run the Bert model with a 2x4 mesh (data x model), which is different
 from the usage1.
 
 ```
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
+python dtensor-bert-train.py --model_size=base --device_type=GPU \
   --num_global_devices=8 --distribution_mode=batchmodel --model_parallel_dim_size=4
 ```
 
@@ -55,7 +55,7 @@ This will run the Bert model with a 4x2 mesh (data x model).
 ! Note that the TPU instance need run with in as "TPU VM architecture" (1 VM).
 
 ```
-python dtensor_bert_train.py --model_size=base --device_type=TPU \
+python dtensor-bert-train.py --model_size=base --device_type=TPU \
   --num_global_devices=8 --distribution_mode=batchmodel
 ```
 
@@ -68,7 +68,7 @@ a distributed mesh with 8x2 (data x model).
 env DTENSOR_CLIENT_ID=0 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
+python dtensor-bert-train.py --model_size=base --device_type=GPU \
   --num_global_devices=16
 ```
 
@@ -76,7 +76,7 @@ python dtensor_bert_train.py --model_size=base --device_type=GPU \
 env DTENSOR_CLIENT_ID=1 DTENSOR_NUM_CLIENTS=2 \
     DTENSOR_JOB_NAME=training \
     DTENSOR_JOBS=host1:9991,host2:9991 \
-python dtensor_bert_train.py --model_size=base --device_type=GPU \
+python dtensor-bert-train.py --model_size=base --device_type=GPU \
   --num_global_devices=16
 ```
 

--- a/dtensor-keras-bert.py
+++ b/dtensor-keras-bert.py
@@ -83,7 +83,6 @@ python dtensor_bert_train.py --model_size=base --device_type=GPU \
 """
 
 import argparse
-import math
 import os
 import time
 
@@ -159,7 +158,7 @@ def configure_virtual_devices(num_device, device_type):
       tf.config.set_logical_device_configuration(phy_devices[n],
                                                  [device_config])
   else:
-    phy_to_logical_ratio = math.ceil(num_device / len(phy_devices))
+    phy_to_logical_ratio = num_device // len(phy_devices)
     for n in range(len(phy_devices)):
       print(f'Config for device id {n}')
       tf.config.set_logical_device_configuration(phy_devices[n], [

--- a/gpu/gce-cluster/bootstrap.sh
+++ b/gpu/gce-cluster/bootstrap.sh
@@ -53,7 +53,7 @@ for i in `seq -s " " -f %03g 1 $COUNT`; do
   INSTANCES+=("${NAME_PREFIX}-${i}")
 done
 
-bash `dirname $0`/../make-cluster-commands.sh "${ZONE}" "${INSTANCES[@]}"
+bash `dirname $0`/../make-cluster-commands.sh "${NAME_PREFIX}" "${ZONE}" "${INSTANCES[@]}"
 
 set -x
 gcloud compute instances bulk create --predefined-names=$(printf "%s," ${INSTANCES[@]} | sed 's/,$//') \

--- a/gpu/gce-cluster/bootstrap.sh
+++ b/gpu/gce-cluster/bootstrap.sh
@@ -98,9 +98,9 @@ bash cluster-run.sh "ls -l dtensor-gcp-examples;"
 cat <<EOF
 Next, run the application with,
 
-  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-app-naive.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-app-naive.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/app_naive"
 
-  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-keras-bert.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-keras-bert.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/keras_bert"
 
 When done, delete the cluster with,
 

--- a/gpu/gce-node/bootstrap.sh
+++ b/gpu/gce-node/bootstrap.sh
@@ -80,15 +80,15 @@ bash cluster-run.sh "ls -l dtensor-gcp-examples;"
 cat <<EOF
 Next, run the application with 4 clients:
 
-  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-app-naive.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-app-naive.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/app_naive"
 
-  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-keras-bert.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; ./launch python dtensor-gcp-examples/dtensor-keras-bert.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/keras_bert"
 
 As there only 1 node, you can also run the application with a single client.
 
-  bash cluster-run.sh "conda activate py310; python dtensor-gcp-examples/dtensor-app-naive.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; python dtensor-gcp-examples/dtensor-app-naive.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/app_naive"
 
-  bash cluster-run.sh "conda activate py310; python dtensor-gcp-examples/dtensor-keras-bert.py --prefix=gs://${GCS_BUCKET}"
+  bash cluster-run.sh "conda activate py310; python dtensor-gcp-examples/dtensor-keras-bert.py --device_type=GPU --ckpt_path_prefix=gs://${GCS_BUCKET}/keras_bert"
 
 When done, delete the cluster with,
 

--- a/gpu/gce-node/bootstrap.sh
+++ b/gpu/gce-node/bootstrap.sh
@@ -48,7 +48,7 @@ esac
 
 INSTANCES=($NAME)
 
-bash `dirname $0`/../make-cluster-commands.sh "${ZONE}" "${INSTANCES[@]}"
+bash `dirname $0`/../make-cluster-commands.sh "${NAME}" "${ZONE}" "${INSTANCES[@]}"
 
 set -x
 gcloud compute instances create $NAME \

--- a/gpu/make-cluster-commands.sh
+++ b/gpu/make-cluster-commands.sh
@@ -27,6 +27,7 @@ else
 fi
 
 cat > cluster-run.sh <<EOF
+trap 'trap "" SIGTERM; kill 0; wait; ' EXIT
 PIDS=()
 mkdir -p /tmp/dtensor/pids
 for i in ${INSTANCES[@]}; do

--- a/gpu/make-cluster-commands.sh
+++ b/gpu/make-cluster-commands.sh
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 
-ZONE=$1
-shift
+NAME=$1
+ZONE=$2
+shift; shift
 INSTANCES=($*)
 
 # If there is a proxy, use it (For Googlers).
@@ -36,9 +37,8 @@ for i in ${INSTANCES[@]}; do
   echo \$i > "/tmp/dtensor/pids/\${CPID}"
 done
 
-while [[ -n "\${PIDS}" ]]; do
-  wait -p CPID -fn "\${PIDS[@]}"
-  PIDS=(\${PIDS[@]/\$CPID})
+for CPID in \${PIDS[@]}; do
+  wait -fn \${CPID}
   NODE=\$(cat /tmp/dtensor/pids/\${CPID})
   echo ===Log from "\${NODE}"===
   cat /tmp/\${NODE}.log

--- a/gpu/make-cluster-commands.sh
+++ b/gpu/make-cluster-commands.sh
@@ -31,17 +31,19 @@ PIDS=()
 mkdir -p /tmp/dtensor/pids
 for i in ${INSTANCES[@]}; do
   echo Running on "\${i}" "\$*"
-  gcloud compute ssh \$i --zone=$ZONE -- -t -q -n "-o ProxyCommand=corp-ssh-helper %h %p" bash -c -l "'\$*'" > /tmp/\${i}.log 2>&1 &
+  gcloud compute ssh \$i --zone=$ZONE -- -t -q -n "-o ProxyCommand=corp-ssh-helper %h %p" bash -c -l "'\$*'" > /tmp/${NAME}_\${i}.log 2>&1 &
   CPID=\$!
   PIDS+=("\${CPID}")
   echo \$i > "/tmp/dtensor/pids/\${CPID}"
 done
 
 for CPID in \${PIDS[@]}; do
-  wait -fn \${CPID}
   NODE=\$(cat /tmp/dtensor/pids/\${CPID})
   echo ===Log from "\${NODE}"===
-  cat /tmp/\${NODE}.log
+  tail -c +0 -f /tmp/${NAME}_\${NODE}.log &
+  TPID=\$!
+  wait -fn \${CPID}
+  kill \${TPID}
 done
 EOF
 

--- a/tpu/README.md
+++ b/tpu/README.md
@@ -36,7 +36,7 @@ $ git clone ...
 $ cd dtensor-gcp-examples/tpu
 
 $ bash bootstrap.sh v2-8
-$ bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --device-type=TPU"
+$ bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --device_type=TPU"
 $ bash cluster-delete.sh
 ```
 
@@ -53,6 +53,6 @@ $ git clone ...
 $ cd dtensor-gcp-examples/tpu
 
 $ bash bootstrap.sh v2-32
-$ bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --device-type=TPU"
+$ bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --device_type=TPU"
 $ bash cluster-delete.sh
 ```

--- a/tpu/bootstrap.sh
+++ b/tpu/bootstrap.sh
@@ -53,6 +53,9 @@ while bash cluster-run.sh ls |grep 'exited with return code'; do
   sleep 10
 done
 
+# TODO: Remove the version pinning after tpu 1vm images are up-to-date.
+bash cluster-run.sh pip3 install tf-models-nightly tensorflow-text-nightly==2.10.0.dev20220718
+
 bash cluster-run.sh "if ! [[ -d dtensor-gcp-examples ]]; then git clone https://github.com/tensorflow/dtensor-gcp-examples; fi"
 bash cluster-run.sh "cd dtensor-gcp-examples; git pull;"
 bash cluster-run.sh "ls -l dtensor-gcp-examples;"

--- a/tpu/bootstrap.sh
+++ b/tpu/bootstrap.sh
@@ -28,7 +28,7 @@ fi
 TOPOLOGY=$1
 NAME="${USER}-dtensor-tpu-${TOPOLOGY}-test"
 ZONE=europe-west4-a
-VERSION="tpu-vm-tf-2.9.1"
+VERSION="v2-nightly"
 NUM_CORES=$(cut -d "-" -f2- <<< $TOPOLOGY)
 export NUM_WORKERS=$(($NUM_CORES / 8))
 export GCS_BUCKET=${GCS_BUCKET:-dtensor-checkpoints}

--- a/tpu/bootstrap.sh
+++ b/tpu/bootstrap.sh
@@ -84,9 +84,9 @@ bash cluster-bcast.sh launch ./
 cat <<EOF
 Next, run the application with,
 
-  bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --prefix=gs://${GCS_BUCKET} --device-type=TPU"
+  bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-app-naive.py --ckpt_path_prefix=gs://${GCS_BUCKET}/app_naive --device_type=TPU"
 
-  bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-keras-bert.py --prefix=gs://${GCS_BUCKET}  --device-type=TPU"
+  bash cluster-run.sh "./launch python3 dtensor-gcp-examples/dtensor-keras-bert.py --ckpt_path_prefix=gs://${GCS_BUCKET}/keras_bert  --device_type=TPU"
 
 When done, delete the cluster with,
 

--- a/tpu/make-cluster-commands.sh
+++ b/tpu/make-cluster-commands.sh
@@ -37,10 +37,12 @@ for ((i=0;i<$NUM_WORKERS;i++)); do
 done
 
 for CPID in \${PIDS[@]}; do
-  wait -fn \${CPID}
   NODE=\$(cat /tmp/dtensor/pids/\${CPID})
   echo ===Log from "\${NODE}"===
-  cat /tmp/${NAME}_\${NODE}.log
+  tail -c +0 -f /tmp/${NAME}_\${NODE}.log &
+  TPID=\$!
+  wait -fn \${CPID}
+  kill \${TPID}
 done
 EOF
 

--- a/tpu/make-cluster-commands.sh
+++ b/tpu/make-cluster-commands.sh
@@ -17,7 +17,6 @@
 NAME=$1
 ZONE=$2
 NUM_WORKERS=$3
-shift
 
 # If there is a proxy, use it (For Googlers).
 if which corp-ssh-helper > /dev/null; then
@@ -37,9 +36,8 @@ for ((i=0;i<$NUM_WORKERS;i++)); do
   echo \$i > "/tmp/dtensor/pids/\${CPID}"
 done
 
-while [[ -n "\${PIDS}" ]]; do
-  wait -p CPID -fn "\${PIDS[@]}"
-  PIDS=(\${PIDS[@]/\$CPID})
+for CPID in \${PIDS[@]}; do
+  wait -fn \${CPID}
   NODE=\$(cat /tmp/dtensor/pids/\${CPID})
   echo ===Log from "\${NODE}"===
   cat /tmp/${NAME}_\${NODE}.log

--- a/tpu/make-cluster-commands.sh
+++ b/tpu/make-cluster-commands.sh
@@ -26,8 +26,6 @@ else
 fi
 
 cat > cluster-run.sh <<EOF
-trap 'trap "" SIGTERM; kill 0; wait; ' EXIT
-
 PIDS=()
 mkdir -p /tmp/dtensor/pids
 for ((i=0;i<$NUM_WORKERS;i++)); do
@@ -38,13 +36,26 @@ for ((i=0;i<$NUM_WORKERS;i++)); do
   echo \$i > "/tmp/dtensor/pids/\${CPID}"
 done
 
+# OSX doesn't have tail --pid.
+function ptail {
+( PID=\$1
+  shift
+  tail \$* &
+  TPID=\$!
+  trap 'kill \${TPID};' EXIT
+  while true; do
+    if ! ps -p \${PID} > /dev/null; then
+      exit 0
+    fi
+    sleep 0.1
+  done
+)
+}
+
 for CPID in \${PIDS[@]}; do
   NODE=\$(cat /tmp/dtensor/pids/\${CPID})
   echo ===Log from "\${NODE}"===
-  tail -c +0 -f /tmp/${NAME}_\${NODE}.log &
-  TPID=\$!
-  wait -fn \${CPID}
-  kill \${TPID}
+  ptail \${CPID} -c +0 -f /tmp/${NAME}_\${NODE}.log
 done
 EOF
 

--- a/tpu/make-cluster-commands.sh
+++ b/tpu/make-cluster-commands.sh
@@ -26,6 +26,8 @@ else
 fi
 
 cat > cluster-run.sh <<EOF
+trap 'trap "" SIGTERM; kill 0; wait; ' EXIT
+
 PIDS=()
 mkdir -p /tmp/dtensor/pids
 for ((i=0;i<$NUM_WORKERS;i++)); do


### PR DESCRIPTION
wait -p requires bash 5.1+, which seems to be unavailable in many systems.
Other changes along the way:
1. tpu switches to v2-nightly images by default.
2. consolidated dtensor-app-naive.py and dtensor-keras-bert.py interface.
3. simplified initialization of dtensor-keras-bert.py.
4. improved cluster-run.sh to follow the output of the 0-th host.
